### PR TITLE
Fix code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,7 +147,7 @@ def pokemon_detail(pokemon_id):
         return "Pokemon not found", 404
     except Exception as e:
         app.logger.error(f"Error in pokemon_detail: {str(e)}")
-        return f"An error occurred: {str(e)}", 500
+        return "An internal error has occurred!", 500
 
 @app.route('/api/search')
 def search_pokemon():


### PR DESCRIPTION
Fixes [https://github.com/kieferhax/pokedex-web-application/security/code-scanning/2](https://github.com/kieferhax/pokedex-web-application/security/code-scanning/2)

To fix the problem, we need to ensure that detailed error messages are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic message.

1. Modify the exception handling block in the `pokemon_detail` function to log the detailed error message and return a generic error message.
2. Ensure that the logging configuration is set up to capture error messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
