### PR TITLE
Fix code scanning alert no. 3: Client-side cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "author": "Your Name",
     "license": "MIT",
     "dependencies": {
-      "express": "^4.17.1"
+      "express": "^4.17.1",
+      "he": "^1.2.0"
     },
     "devDependencies": {
       "nodemon": "^3.1.7"

--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,5 @@
+import he from 'he';
+
 function handleImageError(img) {
     img.onerror = null;
     img.src = '/static/missing-pokemon.png';
@@ -40,7 +42,7 @@ document.getElementById('search').addEventListener('input', debounce(async (e) =
         
         grid.innerHTML = pokemon.map(p => `
             <div class="pokemon-card">
-                <a href="/pokemon/${p.id}?lang=${currentLanguage}">
+                <a href="/pokemon/${p.id}?lang=${he.encode(currentLanguage)}">
                     <img src="${p.sprites.front_default}" 
                          alt="${p.name}" 
                          onerror="handleImageError(this)">


### PR DESCRIPTION
Fixes [https://github.com/kieferhax/pokedex-web-application/security/code-scanning/3](https://github.com/kieferhax/pokedex-web-application/security/code-scanning/3)

To fix the problem, we need to ensure that any user input used in the DOM is properly sanitized or encoded to prevent XSS attacks. In this case, we should encode the `currentLanguage` variable before using it in the template literal. We can use a library like `he` (HTML entities) to encode the user input safely.

1. Install the `he` library to handle HTML encoding.
2. Import the `he` library in the script.
3. Encode the `currentLanguage` variable before using it in the template literal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
