### PR TITLE
Fix code scanning alert no. 4: Client-side cross-site scripting

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -77,7 +77,7 @@ async function loadMorePokemon() {
             if (pokemon.length > 0) {
                 const newCards = pokemon.map(p => `
                     <div class="pokemon-card">
-                        <a href="/pokemon/${p.id}?lang=${currentLanguage}">
+                        <a href="/pokemon/${p.id}?lang=${he.encode(currentLanguage)}">
                             <img src="${p.sprites.front_default}" 
                                  alt="${p.name}" 
                                  onerror="handleImageError(this)">


### PR DESCRIPTION
Fixes [https://github.com/kieferhax/pokedex-web-application/security/code-scanning/4](https://github.com/kieferhax/pokedex-web-application/security/code-scanning/4)

To fix the problem, we need to ensure that any user-provided data is properly sanitized or encoded before being inserted into the HTML. In this case, we can use the `he` library, which is already imported, to encode the `currentLanguage` parameter before using it in the HTML.

- We will use `he.encode` to encode `currentLanguage` before it is used in the `newCards` HTML string.
- This change will be made in the `loadMorePokemon` function where `currentLanguage` is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
